### PR TITLE
Add dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,20 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@3c4e3dcb1aa7874d2c16be7d79418e9b7efd6261
+        with:
+          fail-on-severity: high
+          deny-licenses: GPL-3.0, AGPL-3.0


### PR DESCRIPTION
## Summary
- add a Dependency Review workflow for pull requests
- pin both GitHub Actions to full commit SHAs instead of tags
- fail the check when a PR introduces high or critical vulnerabilities
- block GPL-3.0 and AGPL-3.0 licensed dependencies

## Difference From PR #64
- PR #64 added Dependabot configuration to periodically open update PRs for npm packages and GitHub Actions
- this PR adds a separate pull request-time gate that reviews newly introduced dependency changes before merge
- in other words, PR #64 helps keep dependencies updated over time, while this PR helps prevent risky dependencies from being introduced in new PRs